### PR TITLE
feat(trainer): Implement callback system for training lifecycle

### DIFF
--- a/examples/custom_callback.py
+++ b/examples/custom_callback.py
@@ -1,0 +1,41 @@
+import minari
+import tqdm
+
+from nanodt.agent import NanoDTAgent
+from nanodt.utils import seed_libraries
+from nanodt.trainer import Callback, DecisionTransformerTrainerConfig, TrainingLogs, EvaluationLogs
+
+
+class TqdmCallback(Callback):
+    pbar: tqdm.tqdm
+
+    def on_train_begin(self, config: DecisionTransformerTrainerConfig):
+        self.pbar = tqdm.tqdm(total=config.max_iters, desc="Training Decision Transformer")
+
+    def on_log(self, logs: TrainingLogs, step: int):
+        self.pbar.set_postfix({"loss": f"{logs['loss']:.4f}", "mfu": f"{logs['mfu'] * 100:.2f}%"})
+        self.pbar.update(step - self.pbar.n)
+
+    def on_evaluate(self, logs: EvaluationLogs, step: int):
+        self.pbar.set_description(f"Training (val_loss: {logs['val_loss']:.4f})")
+
+    def on_train_end(self):
+        self.pbar.close()
+
+
+def train_dt():
+    seed = 1234
+    seed_libraries(seed)
+    minari_dataset = minari.load_dataset("mujoco/halfcheetah/medium-v0")
+
+    dt_agent = NanoDTAgent(device="mps")
+    dt_agent.learn(
+        minari_dataset,
+        reward_scale=1000.0,
+        callback=TqdmCallback()
+    )
+    dt_agent.save("output/dt/minari-halfcheetah-medium-v0.pth")
+
+
+if __name__ == "__main__":
+    train_dt()

--- a/src/nanodt/agent.py
+++ b/src/nanodt/agent.py
@@ -3,7 +3,7 @@ import torch
 import gymnasium.spaces as spaces
 
 from nanodt.model import DecisionTransformer, DecisionTransformerConfig
-from nanodt.trainer import DecisionTransformerTrainer, DecisionTransformerTrainerConfig
+from nanodt.trainer import DecisionTransformerTrainer, DecisionTransformerTrainerConfig, DefaultLoggingCallback
 
 
 class NanoDTAgent:
@@ -62,6 +62,9 @@ class NanoDTAgent:
         if not path.endswith(".pth"):
             path += ".pth"
 
+        # Remove the callbacks before saving
+        self.trainer_config.callback = None
+
         torch.save(
             {
                 "model_state_dict": self.model.to("cpu").state_dict(),
@@ -85,6 +88,7 @@ class NanoDTAgent:
 
         # Extract the saved model configuration
         model_config = checkpoint["model_config"]
+        model_config.callback = DefaultLoggingCallback() # Add default logging callback
 
         # Reconstruct the agent object
         agent = cls(


### PR DESCRIPTION
Introduces a flexible callback system to decouple logging and other actions from the core training loop. This makes the trainer more extensible and allows users to easily inject custom logic like progress bars or remote logging.

- Defines a `Callback` protocol with `on_train_begin`, `on_log`, `on_evaluate`, and `on_train_end` hooks.
- Creates a `DefaultLoggingCallback` to preserve the original print-based logging behavior.
- Replaces hardcoded `print` statements in the `DecisionTransformerTrainer` with calls to the appropriate callback hooks.
- Updates agent's save/load methods to correctly handle non-serializable callbacks, ensuring model portability.